### PR TITLE
refa: avoid hard-coded uid in helm chart

### DIFF
--- a/charts/steadybit-extension-jmeter/Chart.yaml
+++ b/charts/steadybit-extension-jmeter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-jmeter
 description: Steadybit jmeter extension Helm chart for Kubernetes.
-version: 1.1.10
+version: 1.1.11
 appVersion: v1.0.16
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-jmeter/templates/deployment.yaml
+++ b/charts/steadybit-extension-jmeter/templates/deployment.yaml
@@ -108,15 +108,10 @@ spec:
             httpGet:
               path: /health/readiness
               port: 8088
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: tmp-dir
           emptyDir: { }

--- a/charts/steadybit-extension-jmeter/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-extension-jmeter/tests/__snapshot__/deployment_test.yaml.snap
@@ -78,12 +78,13 @@ manifest should match snapshot using podAnnotations and Labels:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -170,15 +171,16 @@ manifest should match snapshot with TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
                 - mountPath: /etc/extension/certificates/server-cert
                   name: certificate-server-cert
                   readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -272,12 +274,13 @@ manifest should match snapshot with extra env vars:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -362,12 +365,13 @@ manifest should match snapshot with extra labels:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -456,9 +460,6 @@ manifest should match snapshot with mutual TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
@@ -468,6 +469,10 @@ manifest should match snapshot with mutual TLS:
                 - mountPath: /etc/extension/certificates/server-cert
                   name: certificate-server-cert
                   readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -564,12 +569,13 @@ manifest should match snapshot with mutual TLS using containerPaths:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -652,14 +658,14 @@ manifest should match snapshot with podSecurityContext:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
           securityContext:
+            runAsNonRoot: true
             runAsUser: 2222
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -742,13 +748,14 @@ manifest should match snapshot with priority class:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
           priorityClassName: my-priority-class
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -831,12 +838,13 @@ manifest should match snapshot without TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -921,12 +929,13 @@ should add cluster name from global values:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -1011,12 +1020,13 @@ should add cluster name from local values:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}
@@ -1101,12 +1111,13 @@ should enable location selection:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp-dir
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-jmeter
           volumes:
             - emptyDir: {}

--- a/charts/steadybit-extension-jmeter/values.yaml
+++ b/charts/steadybit-extension-jmeter/values.yaml
@@ -107,7 +107,18 @@ affinity: {}
 priorityClassName: null
 
 # podSecurityContext -- SecurityContext to apply to the pod.
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+  runAsNonRoot: true
+
+# containerSecurityContext -- SecurityContext to apply to the container.
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:


### PR DESCRIPTION
In order to improve installation on openshift, we need to avoid the hard-coded uid/gid in the helm chart