### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.25.9'
+      go_version: '^1.26.2'
       build_linux_packages: false
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Bump Go to 1.26.2
+
 ## v1.0.31
 
 - Bump Go to 1.25.9

--- a/extjmeter/discovery.go
+++ b/extjmeter/discovery.go
@@ -10,7 +10,6 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-jmeter/config"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 	"os"
 )
 
@@ -32,7 +31,7 @@ func (e *jmeterLocationDiscovery) Describe() discovery_kit_api.DiscoveryDescript
 	return discovery_kit_api.DiscoveryDescription{
 		Id: targetType,
 		Discover: discovery_kit_api.DescribingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr(fmt.Sprintf("%ds", 300)),
+			CallInterval: new(fmt.Sprintf("%ds", 300)),
 		},
 	}
 }
@@ -41,9 +40,9 @@ func (e *jmeterLocationDiscovery) DescribeTarget() discovery_kit_api.TargetDescr
 	return discovery_kit_api.TargetDescription{
 		Id:       targetType,
 		Label:    discovery_kit_api.PluralLabel{One: "JMeter Location", Other: "JMeter Locations"},
-		Category: extutil.Ptr("execution locations"),
+		Category: new("execution locations"),
 		Version:  extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:     extutil.Ptr(targetIcon),
+		Icon:     new(targetIcon),
 
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{

--- a/extjmeter/run.go
+++ b/extjmeter/run.go
@@ -55,8 +55,8 @@ func (l *JmeterLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 		Label:       "JMeter",
 		Description: "Execute a JMeter load test.",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:        extutil.Ptr(actionIcon),
-		Technology:  extutil.Ptr("JMeter"),
+		Icon:        new(actionIcon),
+		Technology:  new("JMeter"),
 		Kind:        action_kit_api.LoadTest,
 		TimeControl: action_kit_api.TimeControlInternal,
 		Hint: &action_kit_api.ActionHint{
@@ -67,27 +67,27 @@ func (l *JmeterLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 			{
 				Name:        "file",
 				Label:       "JMeter JMX File",
-				Description: extutil.Ptr("Upload your JMeter Script"),
+				Description: new("Upload your JMeter Script"),
 				Type:        action_kit_api.ActionParameterTypeFile,
-				Required:    extutil.Ptr(true),
-				AcceptedFileTypes: extutil.Ptr([]string{
+				Required:    new(true),
+				AcceptedFileTypes: new([]string{
 					".jmx",
 				}),
-				Order: extutil.Ptr(1),
+				Order: new(1),
 			},
 			{
 				Name:        "parameter",
 				Label:       "JMeter Parameter",
-				Description: extutil.Ptr("Parameters will be accessible from your JMeter Script by ${__P(FOOBAR)}"),
+				Description: new("Parameters will be accessible from your JMeter Script by ${__P(FOOBAR)}"),
 				Type:        action_kit_api.ActionParameterTypeKeyValue,
-				Required:    extutil.Ptr(false),
-				Order:       extutil.Ptr(2),
+				Required:    new(false),
+				Order:       new(2),
 			},
 		},
-		Status: extutil.Ptr(action_kit_api.MutatingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr("5s"),
+		Status: new(action_kit_api.MutatingEndpointReferenceWithCallInterval{
+			CallInterval: new("5s"),
 		}),
-		Stop: extutil.Ptr(action_kit_api.MutatingEndpointReference{}),
+		Stop: new(action_kit_api.MutatingEndpointReference{}),
 	}
 
 	if config.Config.EnableLocationSelection {
@@ -95,11 +95,11 @@ func (l *JmeterLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 			Name:  "-",
 			Label: "Filter JMeter Locations",
 			Type:  action_kit_api.ActionParameterTypeTargetSelection,
-			Order: extutil.Ptr(3),
+			Order: new(3),
 		})
-		description.TargetSelection = extutil.Ptr(action_kit_api.TargetSelection{
+		description.TargetSelection = new(action_kit_api.TargetSelection{
 			TargetType: targetType,
-			DefaultBlastRadius: extutil.Ptr(action_kit_api.DefaultBlastRadius{
+			DefaultBlastRadius: new(action_kit_api.DefaultBlastRadius{
 				Mode:  action_kit_api.DefaultBlastRadiusModeMaximum,
 				Value: 1,
 			}),
@@ -202,7 +202,7 @@ func (l *JmeterLoadTestRunAction) Status(_ context.Context, state *JmeterLoadTes
 	messages := stdOutToMessages(stdOut)
 	log.Debug().Msgf("Returning %d messages", len(messages))
 
-	result.Messages = extutil.Ptr(messages)
+	result.Messages = new(messages)
 	return &result, nil
 }
 
@@ -328,8 +328,8 @@ func (l *JmeterLoadTestRunAction) Stop(_ context.Context, state *JmeterLoadTestR
 
 	log.Debug().Msgf("Returning %d messages", len(messages))
 	return &action_kit_api.StopResult{
-		Artifacts: extutil.Ptr(artifacts),
-		Messages:  extutil.Ptr(messages),
+		Artifacts: new(artifacts),
+		Messages:  new(messages),
 		Error:     resultFailure,
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-jmeter
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
## Summary
- Bump Go to 1.26.2 in go.mod, ci.yml, and Dockerfile
- Apply `go fix ./...` changes