### PR TITLE
fix: resolve data race on the process exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: resolve the data race on the JMeter process exit code between the process-reaping goroutine and the status/stop handlers (via `extcmd.CmdState.Wait`/`ExitCode`)
+
 ## v1.0.38
 
 - chore(deps): bump github.com/steadybit/extension-kit

--- a/extjmeter/run.go
+++ b/extjmeter/run.go
@@ -159,7 +159,7 @@ func (l *JmeterLoadTestRunAction) Start(_ context.Context, state *JmeterLoadTest
 
 	state.Pid = cmd.Process.Pid
 	go func() {
-		cmdErr := cmd.Wait()
+		cmdErr := cmdState.Wait()
 		if cmdErr != nil {
 			log.Error().Msgf("Failed to execute jmeter: %s", cmdErr)
 		}
@@ -181,7 +181,7 @@ func (l *JmeterLoadTestRunAction) Status(_ context.Context, state *JmeterLoadTes
 	var result action_kit_api.StatusResult
 
 	// check if jmeter is still running
-	exitCode := cmdState.Cmd.ProcessState.ExitCode()
+	exitCode := cmdState.ExitCode()
 	stdOut := cmdState.GetLines(false)
 	stdOutToLog(stdOut)
 	if exitCode == -1 {
@@ -237,7 +237,7 @@ func (l *JmeterLoadTestRunAction) Stop(_ context.Context, state *JmeterLoadTestR
 	messages := stdOutToMessages(stdOut)
 
 	// read return code and send it as Message
-	exitCode := cmdState.Cmd.ProcessState.ExitCode()
+	exitCode := cmdState.ExitCode()
 	if exitCode != 0 && exitCode != -1 {
 		messages = append(messages, action_kit_api.Message{
 			Level:   extutil.Ptr(action_kit_api.Error),

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
-	github.com/steadybit/extension-kit v1.10.5
+	github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
-	github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd
+	github.com/steadybit/extension-kit v1.10.6
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.5 h1:KSZP2vUA97QnFDhI3UAAmNg1iOv4n0ckXI/jjKrB3xc=
-github.com/steadybit/extension-kit v1.10.5/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd h1:g3NImsC9j6XyarW9zNUvpkVAPHu2X6ulrPiKe2jvhoI=
+github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd h1:g3NImsC9j6XyarW9zNUvpkVAPHu2X6ulrPiKe2jvhoI=
-github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.10.6 h1:Qz73OO7EMBpueJZjQ23wDXE0xOLBpJOz6h2ND7t6d0s=
+github.com/steadybit/extension-kit v1.10.6/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=


### PR DESCRIPTION
## Problem

`Start` reaped the process in a goroutine (`go cmd.Wait()`, which writes `cmd.ProcessState`) while `Status`/`Stop` read `cmdState.Cmd.ProcessState.ExitCode()` concurrently — a data race that `go test -race` flags and that can yield torn reads of the process result.

## Fix

Use the shared **`extcmd.CmdState.Wait()` / `ExitCode()`** API added in [extension-kit#149](https://github.com/steadybit/extension-kit/pull/149): `CmdState` owns the process result, `Wait()` is the sole reader of `cmd.ProcessState`, and `ExitCode()` returns it race-free (`-1` while running). `Start` now does `go cmdState.Wait()`; the handlers read `cmdState.ExitCode()`.

This is the same fix applied across the four extensions that share this `extcmd` pattern (extension-gatling, extension-jmeter, extension-k6, extension-postman).

## Dependency

`extension-kit` is pinned to the unreleased commit (`v1.10.6-0.20260630192502-059086860afd`) until #149 is merged and tagged; the pin should be bumped to the tagged release before merge.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...` pass.
