### PR TITLE
fix: zip log artifacts in-process instead of shelling out to zip

### DIFF
--- a/extjmeter/artifact.go
+++ b/extjmeter/artifact.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extjmeter
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extfile"
+)
+
+// artifactZipThreshold is the size above which an artifact is zipped before being
+// base64 encoded into the response.
+const artifactZipThreshold = 1000000
+
+// appendFileArtifact appends the file at path as an artifact named label. Files
+// larger than artifactZipThreshold are zipped first, with ".zip" replacing the
+// extension in both the file name and the label. A missing file is skipped.
+func appendFileArtifact(artifacts []action_kit_api.Artifact, path, label string) ([]action_kit_api.Artifact, error) {
+	stats, err := os.Stat(path)
+	if err != nil {
+		return artifacts, nil
+	}
+
+	if stats.Size() > artifactZipThreshold {
+		zipped := replaceExtension(path, ".zip")
+		log.Info().Msgf("Zipping %s to %s", path, zipped)
+		if err := zipFile(path, zipped); err != nil {
+			return artifacts, extension_kit.ToError(fmt.Sprintf("Failed to zip %s", path), err)
+		}
+		path, label = zipped, replaceExtension(label, ".zip")
+	}
+
+	content, err := extfile.File2Base64(path)
+	if err != nil {
+		return artifacts, err
+	}
+	return append(artifacts, action_kit_api.Artifact{Label: label, Data: content}), nil
+}
+
+func replaceExtension(path, ext string) string {
+	return strings.TrimSuffix(path, filepath.Ext(path)) + ext
+}
+
+// zipFile writes src into a newly created zip archive at dst, stored under src's
+// base name.
+func zipFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	w := zip.NewWriter(out)
+	entry, err := w.Create(filepath.Base(src))
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(entry, in); err != nil {
+		return err
+	}
+	return w.Close()
+}

--- a/extjmeter/artifact_test.go
+++ b/extjmeter/artifact_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extjmeter
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_appendFileArtifact_skips_missing_file(t *testing.T) {
+	artifacts, err := appendFileArtifact(nil, filepath.Join(t.TempDir(), "absent.txt"), "log.txt")
+
+	require.NoError(t, err)
+	assert.Empty(t, artifacts)
+}
+
+func Test_appendFileArtifact_attaches_small_file_as_is(t *testing.T) {
+	path := writeFile(t, "log.txt", []byte("some log"))
+
+	artifacts, err := appendFileArtifact(nil, path, "prefix_log.txt")
+
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "prefix_log.txt", artifacts[0].Label)
+	assert.Equal(t, "some log", string(decode(t, artifacts[0])))
+}
+
+func Test_appendFileArtifact_zips_large_file(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), artifactZipThreshold+1)
+	path := writeFile(t, "log.txt", content)
+
+	artifacts, err := appendFileArtifact(nil, path, "prefix_log.txt")
+
+	require.NoError(t, err)
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "prefix_log.zip", artifacts[0].Label)
+	assert.FileExists(t, filepath.Join(filepath.Dir(path), "log.zip"))
+
+	data := decode(t, artifacts[0])
+	assert.Less(t, len(data), len(content), "the archive should be smaller than the file")
+
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "log.txt", r.File[0].Name, "the archive must not contain the file's directories")
+
+	entry, err := r.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = entry.Close() }()
+	unzipped, err := io.ReadAll(entry)
+	require.NoError(t, err)
+	assert.Equal(t, content, unzipped)
+}
+
+func writeFile(t *testing.T, name string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, content, 0644))
+	return path
+}
+
+func decode(t *testing.T, artifact action_kit_api.Artifact) []byte {
+	t.Helper()
+	data, err := base64.StdEncoding.DecodeString(artifact.Data)
+	require.NoError(t, err)
+	return data
+}

--- a/extjmeter/run.go
+++ b/extjmeter/run.go
@@ -249,35 +249,9 @@ func (l *JmeterLoadTestRunAction) Stop(_ context.Context, state *JmeterLoadTestR
 
 	// check if log file exists and send it as artifact
 	filename := fmt.Sprintf("/tmp/steadybit/%v/log.txt", state.ExecutionId)
-	stats, err := os.Stat(filename)
-	if err == nil { // file exists
-		if stats.Size() > 1000000 {
-			//zip if more than 1mb
-			zippedLogs := fmt.Sprintf("/tmp/steadybit/%v/log.zip", state.ExecutionId)
-			log.Info().Msgf("Zip metrics with command: %s %s %s", "zip", zippedLogs, filename)
-			zipCommand := exec.Command("zip", zippedLogs, filename)
-			zipErr := zipCommand.Run()
-			if zipErr != nil {
-				return nil, extension_kit.ToError("Failed to zip log", err)
-			}
-			content, err := extfile.File2Base64(zippedLogs)
-			if err != nil {
-				return nil, err
-			}
-			artifacts = append(artifacts, action_kit_api.Artifact{
-				Label: "$(experimentKey)_$(executionId)_log.zip",
-				Data:  content,
-			})
-		} else {
-			content, err := extfile.File2Base64(filename)
-			if err != nil {
-				return nil, err
-			}
-			artifacts = append(artifacts, action_kit_api.Artifact{
-				Label: "$(experimentKey)_$(executionId)_log.txt",
-				Data:  content,
-			})
-		}
+	artifacts, err = appendFileArtifact(artifacts, filename, "$(experimentKey)_$(executionId)_log.txt")
+	if err != nil {
+		return nil, err
 	}
 
 	//wait until result file is written


### PR DESCRIPTION
## The bug

`extjmeter/run.go` compressed log files larger than 1 MB by shelling out to `zip(1)` — but the runtime image never installs `zip`. The final stage is `azul/zulu-openjdk-alpine:26` plus `coreutils bash procps wget` (Dockerfile:56), and `zip` is not part of that base image.

So **every JMeter run producing more than 1 MB of log output failed its stop step**, and the reason was invisible: the error branch passed `err` — the `os.Stat` error, `nil` at that point — instead of the zip error, so the user got `Failed to zip log` with no cause attached.

Found while removing the same `exec.Command("zip", ...)` from extension-k6 (steadybit/extension-k6#200), where the image *does* install `zip`, so it only cost a package dependency rather than breaking.

## The fix

`archive/zip` from the standard library, via the same `appendFileArtifact` / `zipFile` helpers used in the k6 PR. That also collapses the duplicated size-check/zip/base64/append block into one call.

Deliberately kept local to `extjmeter` rather than extracted into `extension-kit/extfile` — extension-gatling has a third copy of this pattern, so a shared helper is worth doing, but as its own change.

## Behaviour changes

- The archive now stores the file under its **base name** (`log.txt`) instead of the full path `zip(1)` was invoked with (`tmp/steadybit/<executionId>/log.txt`), so unpacking no longer scatters directories.
- A failing compression now reports the actual cause.

Artifact labels, the 1 MB threshold and the `.zip`/`.txt` naming are unchanged. The `result.jtl` artifact is untouched — still always attached uncompressed, whatever its size.

## Tests

New `extjmeter/artifact_test.go` (the package had no tests before) covers the three paths: missing file (skipped), small file (attached as-is), large file (zipped, label switches to `.zip`, archive holds exactly one entry named `log.txt` whose content round-trips).

`go test ./extjmeter/` passes; `go vet` clean; `go mod tidy` is a no-op. The e2e suite doesn't reach this code — it has no artifact assertions, and `action_kit_test` offers none.